### PR TITLE
Refactor async function handling and remove unused jump management in…

### DIFF
--- a/example/example.lang
+++ b/example/example.lang
@@ -1,4 +1,61 @@
+func nameF(params) async {
+    println(params);
+    return "Done " + params;
+}
 
+func awaitable() async {
+    local x = await nameF("Awaitable function called");
+    println("awaitable::x", x);
+    return 69420;
+}
+
+func asyncFn() async {
+    println("Begin");
+    local x = await awaitable();
+    println("Continue", x);
+    await awaitable();
+    return 1;
+}
+
+var x = asyncFn();
+println("Naahhh!!");
+println(x);
+
+func immediate() async {
+    return "Hello";
+}
+
+println(">>", immediate());
+
+var xx = 
+    if (3 < 2)  
+        322 
+    else 
+        220
+    ;
+
+println(xx);
+
+var gg = (2 + 2) switch {
+    | [1,2,3] => 200;
+    | [4,5,6] => 300;
+    | => 20;
+    ;
+};
+
+println("GG:", gg);
+
+func bbbb() {
+    println("hello");
+    return 1;
+}
+
+func cccc() {
+    local x = bbbb();
+    println("cccc->x", x);
+}
+
+cccc();
 
 for (i in 0..10) {
     if (i == 5) {
@@ -6,5 +63,3 @@ for (i in 0..10) {
     }
     println(i);
 }
-
-println("Hey!!");

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "example",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/generator.c
+++ b/src/generator.c
@@ -2134,11 +2134,8 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
                     "while statement must have a condition and a body"
                 );
             }
+            
             scope_t* while_scope = scope_new(_scope, ScopeTypeLoop);
-            while_scope->con_jump = (int*) malloc(sizeof(int));
-            while_scope->brk_jump = (int*) malloc(sizeof(int));
-            while_scope->ccount = 0;
-            while_scope->bcount = 0;
 
             size_t loop_start = here(_code);
             if (generator_is_constant_node(cond) || !generator_is_logical_expression(cond)) {
@@ -2193,23 +2190,6 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
                 }
             }
 
-            // Continue
-            for (size_t i = 0; i < while_scope->ccount; i++) {
-                label_continue(_code, while_scope->con_jump[i], loop_start);
-            }
-            // Break
-            for (size_t i = 0; i < while_scope->bcount; i++) {
-                label(_code, while_scope->brk_jump[i]);
-            }
-
-            // Cleanup jumps
-            free(while_scope->con_jump);
-            free(while_scope->brk_jump);
-            while_scope->con_jump = NULL;
-            while_scope->brk_jump = NULL;
-            while_scope->ccount = 0;
-            while_scope->bcount = 0;
-
             scope_free(while_scope);
             break;
         }
@@ -2226,10 +2206,6 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
             }
 
             scope_t* do_while_scope = scope_new(_scope, ScopeTypeLoop);
-            do_while_scope->con_jump = (int*) malloc(sizeof(int));
-            do_while_scope->brk_jump = (int*) malloc(sizeof(int));
-            do_while_scope->ccount = 0;
-            do_while_scope->bcount = 0;
 
             size_t loop_start = here(_code);
             if (generator_is_constant_node(cond) || !generator_is_logical_expression(cond)) {
@@ -2287,23 +2263,6 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
                 }
             }
 
-            // Continue
-            for (size_t i = 0; i < do_while_scope->ccount; i++) {
-                label_continue(_code, do_while_scope->con_jump[i], loop_start);
-            }
-            // Break
-            for (size_t i = 0; i < do_while_scope->bcount; i++) {
-                label(_code, do_while_scope->brk_jump[i]);
-            }
-
-            // Cleanup jumps
-            free(do_while_scope->con_jump);
-            free(do_while_scope->brk_jump);
-            do_while_scope->con_jump = NULL;
-            do_while_scope->brk_jump = NULL;
-            do_while_scope->ccount = 0;
-            do_while_scope->bcount = 0;
-
             scope_free(do_while_scope);
             break;
         }
@@ -2336,7 +2295,6 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
                 );
             }
             scope_t* for_scope = scope_new(_scope, ScopeTypeLoop);
-            scope_init_jumps(for_scope);
 
             // Start loop
             emit(_code, OPCODE_BEGIN_LOOP_THREAD);
@@ -2478,9 +2436,6 @@ INTERNAL void generator_statement(generator_t* _generator, code_t* _code, scope_
 
             // End loop
             emit(_code, OPCODE_END_LOOP_THREAD);
-
-            // Cleanup jumps
-            scope_clear_scope_jumps(for_scope);
 
             // Free the scope
             scope_free(for_scope);

--- a/src/scope.c
+++ b/src/scope.c
@@ -18,10 +18,6 @@ scope_t* scope_new(scope_t* _parent, scope_type_t _type) {
     scope->captures = (char**) malloc(sizeof(char*));
     ASSERTNULL(scope->captures, "failed to allocate memory for captures");
     scope->captures[0] = NULL;
-    scope->ccount = 0;
-    scope->bcount = 0;
-    scope->con_jump = NULL;
-    scope->brk_jump = NULL;
     scope->is_block = false;
     return scope;
 }
@@ -52,34 +48,6 @@ INTERNAL void scope_rehash(scope_t* _scope) {
     free(_scope->buckets);
     _scope->buckets = new_buckets;
     _scope->bucket_count = new_bucket_count;
-}
-
-void scope_init_jumps(scope_t* _scope) {
-    _scope->ccount = 0;
-    _scope->bcount = 0;
-    _scope->con_jump = (int*) malloc(sizeof(int));
-    _scope->brk_jump = (int*) malloc(sizeof(int));
-    _scope->con_jump[0] = 0;
-    _scope->brk_jump[0] = 0;
-}
-
-void scope_save_con(scope_t* _scope, int _continue) {
-    _scope->con_jump[_scope->ccount++] = _continue;
-    _scope->con_jump = realloc(_scope->con_jump, sizeof(int) * (_scope->ccount + 1));
-}
-
-void scope_save_brk(scope_t* _scope, int _breakpoint) {
-    _scope->brk_jump[_scope->bcount++] = _breakpoint;
-    _scope->brk_jump = realloc(_scope->brk_jump, sizeof(int) * (_scope->bcount + 1));
-}
-
-void scope_clear_scope_jumps(scope_t* _scope) {
-    free(_scope->con_jump);
-    free(_scope->brk_jump);
-    _scope->con_jump = NULL;
-    _scope->brk_jump = NULL;
-    _scope->ccount = 0;
-    _scope->bcount = 0;
 }
 
 bool scope_has(scope_t* _scope, char* _name, bool _recurse) {

--- a/src/scope.h
+++ b/src/scope.h
@@ -44,11 +44,6 @@ typedef struct scope_struct {
     char**         captures;
     // Carry flags
     bool           is_returned;
-    // Continues
-    size_t         ccount;
-    size_t         bcount;
-    int*           con_jump;
-    int*           brk_jump;
     // Block
     bool           is_block;
 } scope_t;
@@ -70,36 +65,6 @@ scope_t* scope_new(scope_t* _parent, scope_type_t _type);
  * @return The new scope.
  */
 scope_t* scope_block_new(scope_t* _parent, scope_type_t _type);
-
-/*
- * Initialize jumps for a scope.
- *
- * @param _scope The scope to initialize.
- */
-void scope_init_jumps(scope_t* _scope);
-
-/*
- * Saves continue statement abs jump address.
- *
- * @param _scope The scope.
- * @param _continue The continue jump absolute address.
- */
-void scope_save_con(scope_t* _scope, int _continue);
-
-/*
- * Saves break statement jump address.
- *
- * @param _scope The scope.
- * @param _breakpoint The jump address for break.
- */
-void scope_save_brk(scope_t* _scope, int _breakpoint);
-
-/*
- * Clears continue and break jump addresses.
- *
- * @param _scope The scope.
- */
-void scope_clear_scope_jumps(scope_t* _scope);
 
 /*
  * Check if a scope has a value.


### PR DESCRIPTION
This pull request makes significant changes to the language's loop scope management and the virtual machine's opcode dispatch logic. The most notable update is the removal of explicit continue/break jump tracking from the `scope_t` structure and related functions, simplifying loop control flow management. Additionally, the opcode handling in the virtual machine (`vm.c`) has been refactored to reorder and group opcode cases more logically, with some opcodes moved or removed. There are also new example programs added to demonstrate async/await and control flow features.

Key changes:

### Loop Scope and Jump Management Simplification

* Removed all continue/break jump tracking fields and functions (`ccount`, `bcount`, `con_jump`, `brk_jump`, and related functions) from `scope_t` and cleaned up their usage in `src/generator.c`, `src/scope.c`, and `src/scope.h`. Loop scope cleanup is now handled by simply freeing the scope. [[1]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecR2137-L2141) [[2]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecL2196-L2212) [[3]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecL2229-L2232) [[4]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecL2290-L2306) [[5]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecL2339) [[6]](diffhunk://#diff-13debaed35b8136e832e52adc0204e6646296010420d855628ab82b3505503ecL2482-L2484) [[7]](diffhunk://#diff-67ad48f2df32e7f22f1d30e1ae63dbe16f8e7aac9b3d77faf5594840730fb6b7L21-L24) [[8]](diffhunk://#diff-67ad48f2df32e7f22f1d30e1ae63dbe16f8e7aac9b3d77faf5594840730fb6b7L57-L84) [[9]](diffhunk://#diff-c8afb449a5006d3200177963910cf3d715137dcda89e62e87afc712e7376f677L47-L51) [[10]](diffhunk://#diff-c8afb449a5006d3200177963910cf3d715137dcda89e62e87afc712e7376f677L74-L103)

### Virtual Machine Opcode Refactoring

* Reorganized the `switch` statement in `vm_execute` to group related opcodes together and moved the handling of several opcodes (e.g., `OPCODE_STORE_NAME`, `OPCODE_STORE_CLASS`, `OPCODE_SET_NAME`, `OPCODE_CALL_METHOD`, `OPCODE_ABSOLUTE_JUMP`, `OPCODE_GET_ITERATOR_OR_JUMP`, `OPCODE_HAS_NEXT`, `OPCODE_GET_NEXT_VALUE`, `OPCODE_GET_NEXT_KEY_VALUE`, `OPCODE_SET_PROPERTY`, `OPCODE_AWAIT`, `OPCODE_RETURN`, `OPCODE_RETURN_ASYNC`, `OPCODE_COMPLETE_BLOCK`, `OPCODE_CONTINUE`, `OPCODE_BREAK`) to new locations for better organization. [[1]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6R1660-R1699) [[2]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L1742-L1751) [[3]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L1774-R1811) [[4]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L2004-L2007) [[5]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L2032-L2111) [[6]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6R2102-R2112) [[7]](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6R2155-R2227)

### Example Code Additions

* Added a comprehensive example program in `example/example.lang` that demonstrates async/await, local variable assignment, switch expressions, function calls, and for-loops, replacing the previous minimal example.

### Cleanup

* Removed the unused `example/package-lock.json` file.

These changes simplify loop handling in the compiler, improve the maintainability and readability of the virtual machine's opcode dispatch, and provide richer example code for language features.… scope